### PR TITLE
Feat/swagger docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "express": "^4.21.2",
         "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.2",
+        "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
@@ -24,6 +25,8 @@
         "@types/jest": "^27.5.2",
         "@types/jsonwebtoken": "^9.0.7",
         "@types/node": "^16.18.122",
+        "@types/swagger-jsdoc": "^6.0.4",
+        "@types/swagger-ui-express": "^4.1.7",
         "jest": "^27.5.1",
         "nodemon": "^2.0.22",
         "prisma": "^6.1.0",
@@ -43,6 +46,68 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -927,6 +992,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -1471,6 +1542,12 @@
         "pretty-format": "^27.0.0"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
+    },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.7.tgz",
@@ -1545,6 +1622,24 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/swagger-jsdoc": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.4.tgz",
+      "integrity": "sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.7.tgz",
+      "integrity": "sha512-ovLM9dNincXkzH4YwyYpll75vhzPBlWx6La89wwvYH7mHjVpf0X0K/vR/aUM7SRxmr5tt9z7E5XJcjQ46q+S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "16.0.9",
@@ -2057,6 +2152,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2249,6 +2350,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/concat-map": {
@@ -2497,6 +2607,18 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/domexception": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -2701,7 +2823,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4466,6 +4587,12 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -4476,6 +4603,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
@@ -4500,6 +4633,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -5006,6 +5145,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/p-limit": {
       "version": "2.3.0",
@@ -5882,6 +6028,59 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/swagger-ui-dist": {
       "version": "5.18.2",
       "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.2.tgz",
@@ -6504,6 +6703,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -6541,6 +6749,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express": "^4.21.2",
     "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.2",
+    "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
@@ -29,6 +30,8 @@
     "@types/jest": "^27.5.2",
     "@types/jsonwebtoken": "^9.0.7",
     "@types/node": "^16.18.122",
+    "@types/swagger-jsdoc": "^6.0.4",
+    "@types/swagger-ui-express": "^4.1.7",
     "jest": "^27.5.1",
     "nodemon": "^2.0.22",
     "prisma": "^6.1.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,7 +2,13 @@
 
 import express from 'express';
 import cors from 'cors';
+import swaggerJsdoc from 'swagger-jsdoc';
+import swaggerUi from 'swagger-ui-express';
+import swaggerOptions from './swagger.config';
 import authRoutes from './routes/auth.routes';
+import courseRoutes from './routes/course.routes';
+import creditRoutes from './routes/credit.routes';
+import enrollmentRoutes from './routes/enrollment.routes';
 
 const app = express();
 
@@ -10,8 +16,23 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+// Swagger setup
+const specs = swaggerJsdoc(swaggerOptions);
+app.use(
+  '/api-docs',
+  swaggerUi.serve,
+  swaggerUi.setup(specs, {
+    explorer: true,
+    customCssUrl:
+      "https://cdn.jsdelivr.net/npm/swagger-ui-themes@3.0.0/themes/3.x/theme-material.css",
+  })
+);
+
 // Routes
 app.use('/api/auth', authRoutes);
+app.use('/api/courses', courseRoutes);
+app.use('/api/credits', creditRoutes);
+app.use('/api/enrollments', enrollmentRoutes);
 
 // Basic route for testing
 app.get('/', (req, res) => {
@@ -33,4 +54,5 @@ const PORT = process.env.PORT || 3000;
 
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);
+  console.log(`Swagger UI available at http://localhost:${PORT}/api-docs`);
 });

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -1,9 +1,75 @@
 // src/routes/auth.routes.ts
-
 import { Router } from 'express';
 import { AuthController } from '../controllers/auth.controller';
 import { validateRequest } from '../middlewares/validate-request';
 import { authValidation } from '../validations/auth.validation';
+
+/**
+ * @swagger
+ * tags:
+ *   name: Auth
+ *   description: 사용자 인증 관련 API
+ */
+
+/**
+ * @swagger
+ * /api/auth/register:
+ *   post:
+ *     summary: 새로운 사용자 등록
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/RegisterRequest'
+ *     responses:
+ *       201:
+ *         description: 회원가입 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthResponse'
+ *       400:
+ *         description: 잘못된 요청
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+
+/**
+ * @swagger
+ * /api/auth/login:
+ *   post:
+ *     summary: 사용자 로그인
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/LoginRequest'
+ *     responses:
+ *       200:
+ *         description: 로그인 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthResponse'
+ *       400:
+ *         description: 잘못된 요청
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: 인증 실패
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 
 const router = Router();
 const authController = new AuthController();

--- a/src/routes/course.routes.ts
+++ b/src/routes/course.routes.ts
@@ -6,6 +6,179 @@ import { courseValidation } from '../validations/course.validation';
 import { authenticateJwt } from '../middlewares/authenticate';
 import { checkAdmin } from '../middlewares/check-admin';
 
+/**
+ * @swagger
+ * tags:
+ *   name: Courses
+ *   description: 과목 관리 API
+ */
+
+/**
+ * @swagger
+ * /api/courses:
+ *   post:
+ *     summary: 새로운 과목 생성 (관리자 전용)
+ *     tags: [Courses]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [code, name, credits, courseType]
+ *             properties:
+ *               code:
+ *                 type: string
+ *                 description: 과목 코드
+ *               name:
+ *                 type: string
+ *                 description: 과목명
+ *               credits:
+ *                 type: integer
+ *                 description: 학점
+ *               courseType:
+ *                 type: string
+ *                 enum: [MAJOR_REQUIRED, MAJOR_ELECTIVE, MAJOR_INTENSIVE, LIBERAL_REQUIRED, LIBERAL_ELECTIVE, GENERAL_ELECTIVE]
+ *                 description: 과목 유형
+ *               prerequisiteId:
+ *                 type: string
+ *                 format: uuid
+ *                 description: 선수과목 ID
+ *               semester:
+ *                 type: string
+ *                 description: 개설 학기
+ *               isRequired:
+ *                 type: boolean
+ *                 description: 필수과목 여부
+ *     responses:
+ *       201:
+ *         description: 과목 생성 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Course'
+ *       400:
+ *         description: 잘못된 요청
+ *       401:
+ *         description: 인증 필요
+ *       403:
+ *         description: 권한 없음
+ *
+ *   get:
+ *     summary: 과목 목록 조회
+ *     tags: [Courses]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: courseType
+ *         schema:
+ *           type: string
+ *           enum: [MAJOR_REQUIRED, MAJOR_ELECTIVE, MAJOR_INTENSIVE, LIBERAL_REQUIRED, LIBERAL_ELECTIVE, GENERAL_ELECTIVE]
+ *         description: 과목 유형 필터
+ *       - in: query
+ *         name: semester
+ *         schema:
+ *           type: string
+ *         description: 학기 필터 (예: 2023-1)
+ *       - in: query
+ *         name: isRequired
+ *         schema:
+ *           type: boolean
+ *         description: 필수과목 여부 필터
+ *     responses:
+ *       200:
+ *         description: 과목 목록 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Course'
+ *       401:
+ *         description: 인증 필요
+ */
+
+/**
+ * @swagger
+ * /api/courses/{id}:
+ *   get:
+ *     summary: 특정 과목 조회
+ *     tags: [Courses]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: 과목 ID
+ *     responses:
+ *       200:
+ *         description: 과목 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Course'
+ *       404:
+ *         description: 과목을 찾을 수 없음
+ *
+ *   put:
+ *     summary: 과목 정보 수정 (관리자 전용)
+ *     tags: [Courses]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: 과목 ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Course'
+ *     responses:
+ *       200:
+ *         description: 과목 수정 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Course'
+ *       403:
+ *         description: 권한 없음
+ *       404:
+ *         description: 과목을 찾을 수 없음
+ *
+ *   delete:
+ *     summary: 과목 삭제 (관리자 전용)
+ *     tags: [Courses]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: 과목 ID
+ *     responses:
+ *       204:
+ *         description: 과목 삭제 성공
+ *       403:
+ *         description: 권한 없음
+ *       404:
+ *         description: 과목을 찾을 수 없음
+ */
 
 const router = Router();
 const courseController = new CourseController();
@@ -13,7 +186,7 @@ const courseController = new CourseController();
 // 과목 생성 (관리자 전용)
 router.post('/', 
   authenticateJwt,
-  checkAdmin,  // 추가
+  checkAdmin,
   validateRequest(courseValidation.create),
   courseController.createCourse.bind(courseController)
 );
@@ -33,7 +206,7 @@ router.get('/:id',
 // 과목 정보 수정 (관리자 전용)
 router.put('/:id',
   authenticateJwt,
-  checkAdmin,  // 추가
+  checkAdmin,
   validateRequest(courseValidation.update),
   courseController.updateCourse.bind(courseController)
 );
@@ -41,9 +214,9 @@ router.put('/:id',
 // 과목 삭제 (관리자 전용)
 router.delete('/:id',
   authenticateJwt,
-  checkAdmin,  // 추가
+  checkAdmin,
   courseController.deleteCourse.bind(courseController)
 );
 
-
 export default router;
+

--- a/src/routes/credit.routes.ts
+++ b/src/routes/credit.routes.ts
@@ -3,17 +3,132 @@ import { Router } from 'express';
 import { CreditController } from '../controllers/credit.controller';
 import { authenticateJwt } from '../middlewares/authenticate';
 
+/**
+ * @swagger
+ * tags:
+ *   name: Credits
+ *   description: 학점 관리 및 졸업요건 확인 API
+ */
+
+/**
+ * @swagger
+ * /api/credits/summary/{userId}:
+ *   get:
+ *     summary: 사용자의 이수학점 현황 조회
+ *     tags: [Credits]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: 사용자 ID
+ *     responses:
+ *       200:
+ *         description: 이수학점 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 totalCredits:
+ *                   type: integer
+ *                   description: 총 이수학점
+ *                 majorRequired:
+ *                   type: integer
+ *                   description: 전공필수 이수학점
+ *                 majorElective:
+ *                   type: integer
+ *                   description: 전공선택 이수학점
+ *                 liberalRequired:
+ *                   type: integer
+ *                   description: 교양필수 이수학점
+ *                 liberalElective:
+ *                   type: integer
+ *                   description: 교양선택 이수학점
+ *       401:
+ *         description: 인증 필요
+ *       403:
+ *         description: 다른 사용자의 정보 조회 불가
+ */
+
+/**
+ * @swagger
+ * /api/credits/graduation-status/{userId}:
+ *   get:
+ *     summary: 사용자의 졸업요건 충족 상태 조회
+ *     tags: [Credits]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: 사용자 ID
+ *     responses:
+ *       200:
+ *         description: 졸업요건 상태 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 isGraduationPossible:
+ *                   type: boolean
+ *                   description: 졸업 가능 여부
+ *                 totalCreditsStatus:
+ *                   type: object
+ *                   properties:
+ *                     required:
+ *                       type: integer
+ *                     current:
+ *                       type: integer
+ *                     isSatisfied:
+ *                       type: boolean
+ *                 majorRequiredStatus:
+ *                   type: object
+ *                   properties:
+ *                     required:
+ *                       type: integer
+ *                     current:
+ *                       type: integer
+ *                     isSatisfied:
+ *                       type: boolean
+ *                 requiredCourses:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       courseId:
+ *                         type: string
+ *                         format: uuid
+ *                       courseName:
+ *                         type: string
+ *                       isCompleted:
+ *                         type: boolean
+ *       401:
+ *         description: 인증 필요
+ *       403:
+ *         description: 다른 사용자의 정보 조회 불가
+ */
+
 const router = Router();
 const creditController = new CreditController();
 
 router.get('/summary/:userId', 
- authenticateJwt, 
- creditController.getCreditsSummary.bind(creditController)
+  authenticateJwt, 
+  creditController.getCreditsSummary.bind(creditController)
 );
 
 router.get('/graduation-status/:userId', 
- authenticateJwt, 
- creditController.getGraduationStatus.bind(creditController)
+  authenticateJwt, 
+  creditController.getGraduationStatus.bind(creditController)
 );
 
 export default router;

--- a/src/routes/enrollment.routes.ts
+++ b/src/routes/enrollment.routes.ts
@@ -3,6 +3,152 @@ import { Router } from 'express';
 import { EnrollmentController } from '../controllers/enrollment.controller';
 import { authenticateJwt } from '../middlewares/authenticate';
 
+/**
+ * @swagger
+ * tags:
+ *   name: Enrollments
+ *   description: 수강신청 관리 API
+ */
+
+/**
+ * @swagger
+ * /api/enrollments:
+ *   post:
+ *     summary: 새로운 수강신청 생성
+ *     tags: [Enrollments]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [courseId, semester]
+ *             properties:
+ *               courseId:
+ *                 type: string
+ *                 format: uuid
+ *                 description: 과목 ID
+ *               semester:
+ *                 type: string
+ *                 description: 수강 학기 (예: 2023-1)
+ *               grade:
+ *                 type: string
+ *                 description: 성적
+ *     responses:
+ *       201:
+ *         description: 수강신청 생성 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Enrollment'
+ *       400:
+ *         description: 이미 수강신청된 과목
+ *       401:
+ *         description: 인증 필요
+ *
+ *   get:
+ *     summary: 수강신청 목록 조회
+ *     tags: [Enrollments]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: semester
+ *         schema:
+ *           type: string
+ *         description: 학기 필터 (예: 2023-1)
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           enum: [PLANNED, ENROLLED, COMPLETED, RETAKING]
+ *         description: 수강신청 상태 필터
+ *     responses:
+ *       200:
+ *         description: 수강신청 목록 조회 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Enrollment'
+ *       401:
+ *         description: 인증 필요
+ */
+
+/**
+ * @swagger
+ * /api/enrollments/{id}:
+ *   put:
+ *     summary: 수강신청 정보 수정
+ *     tags: [Enrollments]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: 수강신청 ID
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               grade:
+ *                 type: string
+ *                 description: 성적
+ *               status:
+ *                 type: string
+ *                 enum: [PLANNED, ENROLLED, COMPLETED, RETAKING]
+ *                 description: 수강신청 상태
+ *     responses:
+ *       200:
+ *         description: 수강신청 정보 수정 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Enrollment'
+ *       401:
+ *         description: 인증 필요
+ *       404:
+ *         description: 수강신청 정보를 찾을 수 없음
+ *
+ *   delete:
+ *     summary: 수강신청 삭제
+ *     tags: [Enrollments]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: 수강신청 ID
+ *     responses:
+ *       200:
+ *         description: 수강신청 삭제 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *       401:
+ *         description: 인증 필요
+ *       404:
+ *         description: 수강신청 정보를 찾을 수 없음
+ */
+
 const router = Router();
 const enrollmentController = new EnrollmentController();
 

--- a/src/swagger.config.ts
+++ b/src/swagger.config.ts
@@ -1,0 +1,151 @@
+// src/swagger.config.ts
+import { Options } from 'swagger-jsdoc';
+
+const swaggerOptions: Options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: '졸업하자 API Documentation',
+      version: '1.0.0',
+      description: '졸업 요건 관리 웹서비스 API 문서'
+    },
+    servers: [
+      {
+        url: 'http://localhost:3000',
+        description: 'Development server'
+      }
+    ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT'
+        }
+      },
+      schemas: {
+        RegisterDTO: {
+          type: 'object',
+          required: ['email', 'password', 'name', 'studentId', 'department', 'admissionYear', 'targetYear'],
+          properties: {
+            email: { type: 'string', format: 'email' },
+            password: { type: 'string', minLength: 6 },
+            name: { type: 'string' },
+            studentId: { type: 'string' },
+            department: { type: 'string' },
+            admissionYear: { type: 'integer', minimum: 1900 },
+            targetYear: { type: 'integer', minimum: 1900 }
+          }
+        },
+        LoginDTO: {
+          type: 'object',
+          required: ['email', 'password'],
+          properties: {
+            email: { type: 'string', format: 'email' },
+            password: { type: 'string' }
+          }
+        },
+        Course: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            code: { type: 'string' },
+            name: { type: 'string' },
+            credits: { type: 'integer', minimum: 1 },
+            courseType: {
+              type: 'string',
+              enum: ['MAJOR_REQUIRED', 'MAJOR_ELECTIVE', 'MAJOR_INTENSIVE', 'LIBERAL_REQUIRED', 'LIBERAL_ELECTIVE', 'GENERAL_ELECTIVE']
+            },
+            prerequisiteId: { type: 'string', format: 'uuid', nullable: true },
+            semester: { type: 'string', nullable: true },
+            isRequired: { type: 'boolean' }
+          }
+        },
+        CreditSummary: {
+          type: 'object',
+          properties: {
+            totalCredits: { type: 'integer' },
+            majorRequired: { type: 'integer' },
+            majorElective: { type: 'integer' },
+            majorIntensive: { type: 'integer' },
+            liberalRequired: { type: 'integer' },
+            liberalElective: { type: 'integer' },
+            generalElective: { type: 'integer' },
+            seniorMajorElective: { type: 'integer' },
+            basicMajor: { type: 'integer' },
+            gpa: { type: 'number', format: 'float' },
+            majorTrack: {
+              type: 'object',
+              properties: {
+                singleMajor: { type: 'integer' },
+                doubleMajor: { type: 'integer' },
+                minorMajor: { type: 'integer' },
+                integratedMajor: { type: 'integer' }
+              }
+            }
+          }
+        },
+        GraduationStatus: {
+          type: 'object',
+          properties: {
+            fulfilled: { type: 'boolean' },
+            current: { $ref: '#/components/schemas/CreditSummary' },
+            selectedTrack: {
+              type: 'string',
+              enum: ['SINGLE', 'DOUBLE', 'MINOR', 'INTEGRATED']
+            },
+            remaining: {
+              type: 'object',
+              properties: {
+                totalCredits: { type: 'integer' },
+                majorRequired: { type: 'integer' },
+                majorElective: { type: 'integer' },
+                liberalRequired: { type: 'integer' },
+                liberalElective: { type: 'integer' },
+                seniorMajorElective: { type: 'integer' },
+                basicMajor: { type: 'integer' },
+                majorTrack: {
+                  type: 'object',
+                  properties: {
+                    singleMajor: { type: 'integer' },
+                    doubleMajor: { type: 'integer' },
+                    minorMajor: { type: 'integer' },
+                    integratedMajor: { type: 'integer' }
+                  }
+                }
+              }
+            },
+            details: {
+              type: 'object',
+              properties: {
+                isTotalCreditsFulfilled: { type: 'boolean' },
+                isMajorRequiredFulfilled: { type: 'boolean' },
+                isMajorElectiveFulfilled: { type: 'boolean' },
+                isLiberalRequiredFulfilled: { type: 'boolean' },
+                isLiberalElectiveFulfilled: { type: 'boolean' },
+                isGPAFulfilled: { type: 'boolean' },
+                isSeniorMajorElectiveFulfilled: { type: 'boolean' },
+                isBasicMajorFulfilled: { type: 'boolean' },
+                majorTrackStatus: {
+                  type: 'object',
+                  properties: {
+                    singleMajor: { type: 'boolean' },
+                    doubleMajor: { type: 'boolean' },
+                    minorMajor: { type: 'boolean' },
+                    integratedMajor: { type: 'boolean' }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    security: [{
+      bearerAuth: []
+    }]
+  },
+  apis: ['./src/routes/*.ts']
+};
+
+export default swaggerOptions;


### PR DESCRIPTION
# API 문서화 - Swagger 도입

## 작업 내용
- Swagger 관련 패키지 설치 및 설정
- API 엔드포인트 문서화 완료
  - 인증 (Auth) API
  - 과목 (Courses) API
  - 학점 (Credits) API
  - 수강신청 (Enrollments) API
- Swagger UI 설정 추가

## 주요 변경사항
- swagger-jsdoc, swagger-ui-express 패키지 추가
- swagger.config.ts 파일 생성 및 스키마 정의
- 각 라우트 파일에 Swagger 문서 주석 추가
- app.ts에 Swagger UI 엔드포인트 추가 (/api-docs)

## 테스트 방법
1. `npm install` 실행하여 새로운 패키지 설치
2. `npm run dev` 로 서버 실행
3. 브라우저에서 `http://localhost:3000/api-docs` 접속하여 API 문서 확인

## 기타
- API 문서는 프로젝트의 types와 validations를 기반으로 작성되었습니다
- 모든 API에 대한 요청/응답 스키마가 정의되어 있습니다
- Swagger UI에서 직접 API 테스트가 가능합니다