### PR TITLE
Feat/api docs swagger

### DIFF
--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -22,7 +22,7 @@ import { authValidation } from '../validations/auth.validation';
  *       content:
  *         application/json:
  *           schema:
- *             $ref: '#/components/schemas/RegisterRequest'
+ *             $ref: '#/components/schemas/RegisterDTO'
  *     responses:
  *       201:
  *         description: 회원가입 성공
@@ -49,7 +49,7 @@ import { authValidation } from '../validations/auth.validation';
  *       content:
  *         application/json:
  *           schema:
- *             $ref: '#/components/schemas/LoginRequest'
+ *             $ref: '#/components/schemas/LoginDTO'
  *     responses:
  *       200:
  *         description: 로그인 성공

--- a/src/routes/course.routes.ts
+++ b/src/routes/course.routes.ts
@@ -31,27 +31,27 @@ import { checkAdmin } from '../middlewares/check-admin';
  *             properties:
  *               code:
  *                 type: string
- *                 description: 과목 코드
+ *                 description: '과목 코드'
  *               name:
  *                 type: string
- *                 description: 과목명
+ *                 description: '과목명'
  *               credits:
  *                 type: integer
- *                 description: 학점
+ *                 description: '학점'
  *               courseType:
  *                 type: string
  *                 enum: [MAJOR_REQUIRED, MAJOR_ELECTIVE, MAJOR_INTENSIVE, LIBERAL_REQUIRED, LIBERAL_ELECTIVE, GENERAL_ELECTIVE]
- *                 description: 과목 유형
+ *                 description: '과목 유형'
  *               prerequisiteId:
  *                 type: string
  *                 format: uuid
- *                 description: 선수과목 ID
+ *                 description: '선수과목 ID'
  *               semester:
  *                 type: string
- *                 description: 개설 학기
+ *                 description: '개설 학기'
  *               isRequired:
  *                 type: boolean
- *                 description: 필수과목 여부
+ *                 description: '필수과목 여부'
  *     responses:
  *       201:
  *         description: 과목 생성 성공
@@ -77,17 +77,17 @@ import { checkAdmin } from '../middlewares/check-admin';
  *         schema:
  *           type: string
  *           enum: [MAJOR_REQUIRED, MAJOR_ELECTIVE, MAJOR_INTENSIVE, LIBERAL_REQUIRED, LIBERAL_ELECTIVE, GENERAL_ELECTIVE]
- *         description: 과목 유형 필터
+ *         description: '과목 유형 필터'
  *       - in: query
  *         name: semester
  *         schema:
  *           type: string
- *         description: 학기 필터 (예: 2023-1)
+ *         description: '학기 필터 (예시 - 2023-1)'
  *       - in: query
  *         name: isRequired
  *         schema:
  *           type: boolean
- *         description: 필수과목 여부 필터
+ *         description: '필수과목 여부 필터'
  *     responses:
  *       200:
  *         description: 과목 목록 조회 성공
@@ -116,7 +116,7 @@ import { checkAdmin } from '../middlewares/check-admin';
  *         schema:
  *           type: string
  *           format: uuid
- *         description: 과목 ID
+ *         description: '과목 ID'
  *     responses:
  *       200:
  *         description: 과목 조회 성공
@@ -139,7 +139,7 @@ import { checkAdmin } from '../middlewares/check-admin';
  *         schema:
  *           type: string
  *           format: uuid
- *         description: 과목 ID
+ *         description: '과목 ID'
  *     requestBody:
  *       required: true
  *       content:
@@ -170,7 +170,7 @@ import { checkAdmin } from '../middlewares/check-admin';
  *         schema:
  *           type: string
  *           format: uuid
- *         description: 과목 ID
+ *         description: '과목 ID'
  *     responses:
  *       204:
  *         description: 과목 삭제 성공
@@ -219,4 +219,3 @@ router.delete('/:id',
 );
 
 export default router;
-

--- a/src/routes/enrollment.routes.ts
+++ b/src/routes/enrollment.routes.ts
@@ -29,13 +29,13 @@ import { authenticateJwt } from '../middlewares/authenticate';
  *               courseId:
  *                 type: string
  *                 format: uuid
- *                 description: 과목 ID
+ *                 description: '과목 ID'
  *               semester:
  *                 type: string
- *                 description: 수강 학기 (예: 2023-1)
+ *                 description: '수강 학기 (예시 - 2023-1)'
  *               grade:
  *                 type: string
- *                 description: 성적
+ *                 description: '성적'
  *     responses:
  *       201:
  *         description: 수강신청 생성 성공
@@ -58,13 +58,13 @@ import { authenticateJwt } from '../middlewares/authenticate';
  *         name: semester
  *         schema:
  *           type: string
- *         description: 학기 필터 (예: 2023-1)
+ *         description: '학기 필터 (예시 - 2023-1)'
  *       - in: query
  *         name: status
  *         schema:
  *           type: string
  *           enum: [PLANNED, ENROLLED, COMPLETED, RETAKING]
- *         description: 수강신청 상태 필터
+ *         description: '수강신청 상태 필터'
  *     responses:
  *       200:
  *         description: 수강신청 목록 조회 성공
@@ -93,7 +93,7 @@ import { authenticateJwt } from '../middlewares/authenticate';
  *         schema:
  *           type: string
  *           format: uuid
- *         description: 수강신청 ID
+ *         description: '수강신청 ID'
  *     requestBody:
  *       required: true
  *       content:
@@ -103,11 +103,11 @@ import { authenticateJwt } from '../middlewares/authenticate';
  *             properties:
  *               grade:
  *                 type: string
- *                 description: 성적
+ *                 description: '성적'
  *               status:
  *                 type: string
  *                 enum: [PLANNED, ENROLLED, COMPLETED, RETAKING]
- *                 description: 수강신청 상태
+ *                 description: '수강신청 상태'
  *     responses:
  *       200:
  *         description: 수강신청 정보 수정 성공
@@ -132,7 +132,7 @@ import { authenticateJwt } from '../middlewares/authenticate';
  *         schema:
  *           type: string
  *           format: uuid
- *         description: 수강신청 ID
+ *         description: '수강신청 ID'
  *     responses:
  *       200:
  *         description: 수강신청 삭제 성공

--- a/src/swagger.config.ts
+++ b/src/swagger.config.ts
@@ -45,6 +45,32 @@ const swaggerOptions: Options = {
             password: { type: 'string' }
           }
         },
+        AuthResponse: {
+          type: 'object',
+          properties: {
+            token: { type: 'string' },
+            user: {
+              type: 'object',
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                email: { type: 'string', format: 'email' },
+                name: { type: 'string' },
+                studentId: { type: 'string' },
+                department: { type: 'string' },
+                admissionYear: { type: 'integer' },
+                targetYear: { type: 'integer' },
+                role: { type: 'string', enum: ['ADMIN', 'STUDENT'] }
+              }
+            }
+          }
+        },
+        ErrorResponse: {
+          type: 'object',
+          properties: {
+            error: { type: 'string' },
+            message: { type: 'string' }
+          }
+        },
         Course: {
           type: 'object',
           properties: {
@@ -59,6 +85,21 @@ const swaggerOptions: Options = {
             prerequisiteId: { type: 'string', format: 'uuid', nullable: true },
             semester: { type: 'string', nullable: true },
             isRequired: { type: 'boolean' }
+          }
+        },
+        Enrollment: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            userId: { type: 'string', format: 'uuid' },
+            courseId: { type: 'string', format: 'uuid' },
+            grade: { type: 'string', nullable: true },
+            semester: { type: 'string' },
+            status: {
+              type: 'string',
+              enum: ['PLANNED', 'ENROLLED', 'COMPLETED', 'RETAKING']
+            },
+            course: { $ref: '#/components/schemas/Course' }
           }
         },
         CreditSummary: {


### PR DESCRIPTION
# API 문서화 - Swagger 설정

## 변경사항
- Swagger 설정 파일 추가 및 API 스키마 정의
  - 인증 관련 스키마 (RegisterDTO, LoginDTO, AuthResponse)
  - 과목 관련 스키마 (Course)
  - 학점/졸업요건 관련 스키마 (CreditSummary, GraduationStatus)
  - 수강신청 관련 스키마 (Enrollment)
  - 에러 응답 스키마 (ErrorResponse)

- API 엔드포인트 문서화
  - 인증 API (/api/auth/*)
  - 과목 관리 API (/api/courses/*)
  - 수강신청 API (/api/enrollments/*)

## 주요 내용
- OpenAPI 3.0 스펙을 따르는 API 문서 작성
- 모든 API 엔드포인트에 대한 상세 설명 추가
- 요청/응답 스키마 정의 및 참조 구현
- Bearer 토큰 인증 설정 추가

## 테스트 방법
1. `npm install` 실행으로 swagger 관련 패키지 설치
2. `npm run dev`로 서버 실행
3. http://localhost:3000/api-docs 에서 API 문서 확인

## 기타 사항
- API 문서는 프로젝트의 타입 정의와 일치하도록 작성됨
- Swagger UI에서 API 직접 테스트 가능
- 필요한 경우 추가 스키마 정의나 문서 업데이트 예정